### PR TITLE
Update endswith.rst to not use startswith syntax

### DIFF
--- a/source/docs/str/endswith.rst
+++ b/source/docs/str/endswith.rst
@@ -8,7 +8,7 @@ Returns a Boolean stating whether a string ends with the specified suffix.
 
 Syntax
 ------
-**str**. *startswith(suffix[, start[, end]])*
+**str**. *endswith(suffix[, start[, end]])*
 
 *suffix*
     Required. The substring looked for. *suffix* can also be a tuple of suffixes to look for.


### PR DESCRIPTION
Fixes typo of using startswith in the syntax instead of endswith.

![Copy Paste](http://d.gr-assets.com/books/1457364208l/29437996.jpg)
