### PR TITLE
Added return value

### DIFF
--- a/source/docs/dunderattr/getattribute.rst
+++ b/source/docs/dunderattr/getattribute.rst
@@ -44,7 +44,7 @@ Example
 >>> class Frob(object):
 ...     def __getattribute__(self, name):
 ...         print "getting `{}`".format(str(name))
-...         object.__getattribute__(self, name)
+...         return object.__getattribute__(self, name)
 ... 
 >>> f = Frob()
 >>> f.bamf = 10


### PR DESCRIPTION
The `__getattribute__` method is pointless without a return value.