### PR TITLE
Corrected inaccuracies in boilerplate index.rst

### DIFF
--- a/source/docs/boilerplate/index.rst
+++ b/source/docs/boilerplate/index.rst
@@ -2,15 +2,14 @@
 Boilerplate
 ===========
 
+`#!/usr/bin/env/python`_
+    Searches the executable PATH for a Python executable.
+`#!/usr/local/bin/python`_
+    For Python executables not managed by a distribution package manager.
+`#!/usr/bin/python`_
+    The default Python will be located and used.
+`# -*- coding: utf-8 -*-`_
+    Declares usage of UTF-8 characters in the script.    
 `if __name__ == '__main__':  main()`_
     Prevents main() from being executed during imports.
-`#!/usr/bin/env/python`_
-    UNIX specific. 
-`#!/usr/local/bin/python`_
-    UNIX specific. 
-`#!/usr/bin/python`_
-    UNIX specific. 
-`# -*- coding: utf-8 -*-`_
-    Declares usage of UTF-8 characters in the script.
-    
     


### PR DESCRIPTION
Virtual shebangs make the "linux-style" shebangs perfectly applicable to Windows (meaning they are not UNIX specific).  See https://docs.python.org/3/using/windows.html#shebang-lines .

Moved code snippets to be in script-order (they appear here in the order they would appear in a script).