### PR TITLE
Fix code example outputs + use `print()` function (not statement)

### DIFF
--- a/source/docs/functions/staticmethod.rst
+++ b/source/docs/functions/staticmethod.rst
@@ -36,7 +36,7 @@ Example 1
 >>> class Foo:
 ...     @staticmethod
 ...     def bar():
-...         print 'bar'
+...         print("bar")
 ...
 >>> Foo.bar
 <function bar at 0x00DBC1B0>
@@ -45,14 +45,14 @@ Example 1
 >>> Foo.bar()
 bar
 >>> Foo().bar()
-Bar
+bar
 
 Example 2
 =========
->>> # this example uses obsolete no-decorator syntax
+>>> # This example uses the obsolete no-decorator syntax.
 >>> class Foo:
 ...     def bar():
-...         print 'bar'
+...         print("bar")
 ...     bar = staticmethod(bar)
 ...
 >>> Foo.bar
@@ -62,7 +62,7 @@ Example 2
 >>> Foo().bar()
 bar
 >>> Foo.bar()
-bar*
+bar
 	
 
 See Also


### PR DESCRIPTION
I have fixed the code examples that show incorrect outputs: `Bar -> bar` and `bar* -> bar`.

Also, the `print` statement is now a thing of the past. Code examples should, therefore, rather express the `print()` function usage as to not confuse beginners who in vast majority already use Python 3.x where `print()` is only available as a function now, and not as a statement anymore.