### PR TITLE
"dict unpack" as it were a list values

### DIFF
--- a/source/docs/operators/dict_unpack.rst
+++ b/source/docs/operators/dict_unpack.rst
@@ -32,4 +32,12 @@ Example
 
 See also
 ========
+
+In purpose of unpack a dict values as it were a list values.
+
+>>> from operator import itemgetter
+>>> d = {'foo': 1, 'bar': 2, 'baz': 3}
+>>> foo, baz = itemgetter('foo', 'baz')(d)
+(1, 3)
+
 #TODO


### PR DESCRIPTION
When code like

```python
return foo, bar, baz
```

Refactored to

```python
return { 'foo': foo, 'bar': bar, 'baz': baz }
```

It's handy to refactor client part like:

```diff
++ from operator import itemgetter
-- foo, bar, baz = some_f()
++ foo, bar, baz = itemgetter('foo', 'bar', 'baz')(some_f())
```