### PR TITLE
Update bitwise_left_shift_assignment.rst

### DIFF
--- a/source/docs/operators/bitwise_left_shift_assignment.rst
+++ b/source/docs/operators/bitwise_left_shift_assignment.rst
@@ -8,7 +8,7 @@ Performs bitwise left shift and assigns value to the left operand.
 
 Syntax
 ======
-A >>= B
+A <<= B
 
 *A*
     Integer object.


### PR DESCRIPTION
Fix what appears to be a copy-paste typo in the Syntax section, which I'm guessing occurred when this content was copied from the "Bitwise Right Shift Assignment" docs