### PR TITLE
Update time complexity in update.rst

### DIFF
--- a/source/docs/dict/update.rst
+++ b/source/docs/dict/update.rst
@@ -19,7 +19,7 @@ Return Value
 
 Time Complexity
 ===============
-#TODO
+$O(N)$ - linear time
 
 Example 1
 =========


### PR DESCRIPTION
The time complexity of dictionary update is linear, i.e. $O(N)$. The C implementation of Python dictionary does resizing, hasing and deleting in an amortized $O(1)$ time. So, the update method, which uses the C implementation of the `dict_merge()` function as source, uses a for loop to update the dictionary.

Sources:
https://hg.python.org/cpython/file/tip/Objects/dictobject.c
https://archive.org/details/pyvideo_276___the-mighty-dictionary-55
https://stackoverflow.com/questions/20906435/does-dictionary-do-resize-when-we-delete-an-item
https://stackoverflow.com/questions/52504598/time-complexity-of-python-dictionary-get-update-always-o1